### PR TITLE
Add corpus-level boilerplate filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LexRank Summarizer
 
-This is a Spark-based extractive summarizer, based on the [LexRank algorithm](http://arxiv.org/pdf/1109.2128.pdf).  It extracts the 5 "most informative" sentences from each document in the corpus.
+This is a Spark-based extractive summarizer, based on the [LexRank algorithm](http://arxiv.org/pdf/1109.2128.pdf).  It extracts a 5 sentence summary from each document in the corpus.
+
+Boilerplate language is detected across documents in the corpus using pairwise comparisons of sentence similarity.  The similarity computations use the [DIMSUM algorithm](http://arxiv.org/abs/1304.1467) to reduce the computational effort involved.
 
 ## Usage
 
@@ -13,6 +15,10 @@ Options:
 -i PATH, --input PATH          Relative path of input files (default: "./input")
 -o PATH, --output PATH         Relative path of output files (default: "./output")
 -s PATH, --stopwords PATH      Relative path of stopwords file (default: "./stopwords")
+-l VALUE, --length VALUE       Number of sentences to extract from each document (default: 5) 
+-b VALUE, --boilerplate VALUE  Similarity cutoff for cross-document boilerplate filtering (default: 0.8)
+-t VALUE, --threshold VALUE    Similarity threshold for LexRank graph construction (default: 0.1)
+-c VALUE, --convergence VALUE  Convergence tolerance for PageRank graph computation (default: 0.001)
 ```
 
 ### File Formats

--- a/src/main/scala/io/github/karlhigley/summarizer.scala
+++ b/src/main/scala/io/github/karlhigley/summarizer.scala
@@ -1,16 +1,16 @@
 package io.github.karlhigley
 
 import scala.io.Source
+import scala.math.max
 
 import org.apache.spark.{SparkContext, SparkConf, Logging}
 import org.apache.spark.rdd.RDD
 
 import org.apache.spark.mllib.feature.{HashingTF, IDF, Normalizer}
-import org.apache.spark.mllib.linalg.{Vector}
+import org.apache.spark.mllib.linalg.{Vector, SparseVector}
+import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry, RowMatrix}
 
 import org.apache.spark.graphx._
-
-import breeze.linalg.{DenseVector => BDV}
 
 import chalk.text.analyze.PorterStemmer
 import chalk.text.segment.JavaSentenceSegmenter
@@ -19,50 +19,86 @@ import chalk.text.tokenize.SimpleEnglishTokenizer
 case class Document(id: String, text: String)
 case class Sentence(id: Long, docId: String, text: String)
 case class SentenceTokens(id: Long, docId: String, tokens: Seq[String])
-case class SentenceFeatures(id: Long, docId: String, features: Vector)
+case class SentenceFeatures(id: Long, docId: String, features: SparseVector)
+case class SentenceComparison(id1: Long, id2: Long, similarity: Double)
 
 class LexRank(sentences: RDD[Sentence], features: RDD[SentenceFeatures]) extends Serializable {
-  def summarize() = {
-    val graph  = buildGraph(features, 0.1)
-    val scores = graph.pageRank(0.0001).vertices   
-    selectExcerpts(sentences, scores)   
+  def summarize(length: Int = 5, threshold: Double = 0.1, cutoff: Double = 0.8, convergence: Double = 0.001) = {    
+    val graph        = buildGraph(features, threshold, cutoff)
+    val scores       = graph.pageRank(convergence).vertices   
+    selectExcerpts(sentences, scores, length)   
   }
 
-  private def dot(v1: Vector, v2: Vector) : Double = {
-    BDV(v1.toArray).dot(BDV(v2.toArray))
+  private def buildGraph(features: RDD[SentenceFeatures], threshold: Double, cutoff: Double): Graph[String, Double] = {
+    val comparisons         = compareSentences(features, threshold)
+    val filteredGraph       = removeBoilerplate(comparisons, cutoff)
+
+    val docIds              = features.map(f => (f.id, f.docId))
+    val documentComponents  = removeCrossDocEdges(filteredGraph, docIds)
+
+    documentComponents
   }
 
-  private def buildGraph(features: RDD[SentenceFeatures], threshold: Double): Graph[Vector, Double] = {
-    val edges =
-      features
-        .map(f => (f.docId, f))
-        .groupByKey()
-        .flatMap {
-          case (docId, docFeatures) =>
-            for {
-              a <- docFeatures
-              b <- docFeatures
-              if a.id != b.id
-            } yield (a,b)
-        }
-        .flatMap({
-          case (a: SentenceFeatures, b: SentenceFeatures) =>
-            dot(a.features, b.features) match {
-              case similarity if similarity > threshold => Some(Edge(a.id, b.id, similarity))
-              case _ => None
-            }
-        })
-    val vertices = features.map(f => (f.id, f.features))
-    Graph(vertices, edges)
+  private def removeBoilerplate(comparisons: RDD[SentenceComparison], boilerplateCutoff: Double): Graph[Double, Double] = {
+    val edges = comparisons
+                  .flatMap(c => SentenceComparison.unapply(c))
+                  .map(e => Edge(e._1, e._2, e._3))
+
+    val maxSimilarityVertices = Graph.fromEdges(edges, 0).aggregateMessages[Double](
+      sendMsg       = triplet => triplet.sendToDst(triplet.attr),
+      mergeMsg      = (a, b) => max(a,b),
+      tripletFields = TripletFields.EdgeOnly
+    )
+
+    val maxSimilarityGraph: Graph[Double, Double] = Graph(maxSimilarityVertices, edges, 1.0)
+    maxSimilarityGraph.subgraph(vpred = (id, attr) => attr < boilerplateCutoff)  
   }
 
-  private def selectExcerpts(sentences: RDD[Sentence], ranks: VertexRDD[Double]) = {
+  private def removeCrossDocEdges(graph: Graph[Double, Double], docIds: RDD[(Long, String)]): Graph[String, Double] = {
+    val docGraph: Graph[String, Double] = graph.outerJoinVertices(docIds)(
+      (id, similarity, docIdOpt) => docIdOpt match {
+        case Some(docId)  => docId
+        case None         => ""
+      }
+    )
+    docGraph.subgraph(
+      epred = (triplet)   => triplet.srcAttr == triplet.dstAttr,
+      vpred = (id, attr)  => attr != ""
+    )
+  }
+
+  private def selectExcerpts(sentences: RDD[Sentence], ranks: VertexRDD[Double], length: Int) = {
     ranks
       .join(sentences.map(s => (s.id, s)))
       .map { case (_, (rank, sentence)) => (sentence.docId, (rank, sentence.id, sentence.text)) }
       .groupByKey()
-      .flatMap { case (docId, sentences) => sentences.toSeq.sortWith(_._1 > _._1).take(5).map(e => (docId, e._3)) }
+      .flatMap { case (docId, sentences) => sentences.toSeq.sortWith(_._1 > _._1).take(length).map(e => (docId, e._3)) }
   }
+
+  private def compareSentences(columns: RDD[SentenceFeatures], threshold: Double): RDD[SentenceComparison] = {
+    buildRowMatrix(columns)
+      .columnSimilarities(threshold)
+      .entries
+      .flatMap(MatrixEntry.unapply(_))
+      .map(SentenceComparison.tupled)
+      .filter(_.similarity > threshold)
+  }
+
+  private def buildRowMatrix(columns: RDD[SentenceFeatures]) : RowMatrix = {   
+    val matrixEntries = columns.flatMap {
+      case SentenceFeatures(colNum, _, vector) =>
+        sparseElements(vector).map {
+          case (rowNum, value) => MatrixEntry(rowNum, colNum, value)
+        }
+    }
+
+    new CoordinateMatrix(matrixEntries).toRowMatrix()
+  }
+
+  private def sparseElements(vector: SparseVector): Seq[(Int, Double)] = {
+    vector.indices.zip(vector.values)
+  }
+
 }
 
 object LexRank {
@@ -92,18 +128,17 @@ object LexRank {
 
   private def vectorize(tokens: RDD[SentenceTokens]) : RDD[SentenceFeatures] = {
     val hashingTF  = new HashingTF()
-    val normalizer = new Normalizer()
     val idfModel   = new IDF()
 
     val termFrequencies = tokens.map(t => {
-        SentenceFeatures(t.id, t.docId, hashingTF.transform(t.tokens))
+        (t.id, t.docId, hashingTF.transform(t.tokens))
     })
     
-    val idf = idfModel.fit(termFrequencies.map({ case SentenceFeatures(_, _, tf) => tf }))
+    val idf = idfModel.fit(termFrequencies.map({ case (_, _, tf) => tf }))
 
     termFrequencies.map({
-      case SentenceFeatures(id, docId, tf) =>
-        val featureVector = normalizer.transform(idf.transform(tf))
+      case (id, docId, tf) =>
+        val featureVector = idf.transform(tf).asInstanceOf[SparseVector]
         SentenceFeatures(id, docId, featureVector)
     })
   }
@@ -122,6 +157,11 @@ class Configuration(args: Array[String]) {
   var outputPath    = "output"
   var stopwordsPath = "stopwords"
 
+  var length        = 5
+  var cutoff        = 0.8
+  var threshold     = 0.1
+  var convergence   = 0.001
+
   parse(args.toList)
 
   private def parse(args: List[String]): Unit = args match {
@@ -135,6 +175,22 @@ class Configuration(args: Array[String]) {
 
     case ("--stopwords" | "-s") :: path :: tail =>
       stopwordsPath = path
+      parse(tail)
+
+    case ("--length" | "-l") :: value :: tail =>
+      length = value.toInt
+      parse(tail)
+
+    case ("--boilerplate" | "-b") :: value :: tail =>
+      cutoff = value.toDouble
+      parse(tail)
+
+    case ("--threshold" | "-t") :: value :: tail =>
+      threshold = value.toDouble
+      parse(tail)
+
+    case ("--convergence" | "-c") :: value :: tail =>
+      convergence = value.toDouble
       parse(tail)
 
     case ("--help" | "-h") :: tail =>
@@ -155,6 +211,10 @@ class Configuration(args: Array[String]) {
       |   -i PATH, --input PATH          Relative path of input files (default: "./input")
       |   -o PATH, --output PATH         Relative path of output files (default: "./output")
       |   -s PATH, --stopwords PATH      Relative path of stopwords file (default: "./stopwords")
+      |   -l VALUE, --length VALUE       Number of sentences to extract from each document (default: 5) 
+      |   -b VALUE, --boilerplate VALUE  Similarity cutoff for cross-document boilerplate filtering (default: 0.8)
+      |   -t VALUE, --threshold VALUE    Similarity threshold for LexRank graph construction (default: 0.1)
+      |   -c VALUE, --convergence VALUE  Convergence tolerance for PageRank graph computation (default: 0.001)
      """.stripMargin
     System.err.println(usage)
     System.exit(exitCode)
@@ -180,7 +240,7 @@ object Summarizer extends Logging {
     )
 
     val model    = LexRank.featurize(documents, stopwords)
-    val excerpts = model.summarize()
+    val excerpts = model.summarize(config.length, config.threshold, config.cutoff, config.convergence)
 
 	excerpts
       .map(_.productIterator.toList.mkString("\t"))


### PR DESCRIPTION
Some collections of documents contain repeated language that is used in
many documents (i.e. boilerplate). This presents a challenge to extractive
summarization based on sentence similarity and graph centrality, since
sections of boilerplate language may contain many sentences using
overlapping words, which results in high similarity scores between
boilerplate sentences, and therefore also in densely connected components
in documents' sentence graphs.  Those densely connected subgraphs skew
the centrality computation in a way that can result in completely
uninformative summaries.

In order to compensate for that effect, this commit filters out sentences
above a certain similarity score (i.e. boilerplate threshold) across the
whole corpus. The intuition is that highly similar sentence pairs across
documents likely represent repetitively structured language. While the
information contained by such sentences may sometimes be of legitimate
interest, that information can probably be extracted more efficiently
and effectively using other (non-summarization) techniques.

Finding similar sentences across the documents in the corpus requires
pairwise comparison between all sentences in the corpus; for a naive
approach, the level of computational effort grows quadratically with the
number of sentences in the corpus.  Rather than naively computing cosine
similarities for every pair in the cartesian product of sentences, this uses
the `computeSimilarities` method on Spark's RowMatrix class.
`computeSimilarities` implements Twitter's DIMSUM algorithm, which
estimates the cosine similarity of vector pairs using a sampling scheme
that focuses the computational effort on pairs above a certain similarity
threshold.

When the DIMSUM threshold is set to 0, the algorithm reduces to the
exact computation of all pairwise similarities. Since edges in the LexRank
sentence graph will be filtered to select similarities above a certain
threshold (i.e. 0.1), that threshold is also the desired lower bound for low
error similarity computation.

Not surprisingly, `computeSimilarities` is faster than the previous
implementation, even with sampling turned off.  The cosine similarity is
now computed directly, instead of first normalizing the vectors and then
computing a dot product. (Since DIMSUM's sampling scheme relies on the size
of the vectors, normalizing would now thwart the optimization provided by
sampling.) Direct computation of the cosine similarity avoids a number
of awkward and slow operations in the previous implementation, including the
conversion from Spark `SparseVector`s into Breeze `DenseVector`s
involved in the dot product computation.
