### PR TITLE
Uses locality-sensitive hashing to group similar sentences into buckets

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Configuration.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Configuration.scala
@@ -9,6 +9,8 @@ class Configuration(args: Array[String]) {
   var cutoff        = 0.8
   var threshold     = 0.1
   var convergence   = 0.001
+  
+  var partitions: Option[Int] = None
 
   parse(args.toList)
 
@@ -23,6 +25,10 @@ class Configuration(args: Array[String]) {
 
     case ("--stopwords" | "-s") :: path :: tail =>
       stopwordsPath = path
+      parse(tail)
+
+    case ("--partitions" | "-p") :: value :: tail =>
+      partitions = Some(value.toInt)
       parse(tail)
 
     case ("--length" | "-l") :: value :: tail =>
@@ -59,6 +65,7 @@ class Configuration(args: Array[String]) {
       |   -i PATH, --input PATH          Relative path of input files (default: "./input")
       |   -o PATH, --output PATH         Relative path of output files (default: "./output")
       |   -s PATH, --stopwords PATH      Relative path of stopwords file (default: "./stopwords")
+      |   -p VALUE, --partitions VALUE   Number of partitions for documents (default: automatic by Spark)
       |   -l VALUE, --length VALUE       Number of sentences to extract from each document (default: 5) 
       |   -b VALUE, --boilerplate VALUE  Similarity cutoff for cross-document boilerplate filtering (default: 0.8)
       |   -t VALUE, --threshold VALUE    Similarity threshold for LexRank graph construction (default: 0.1)

--- a/src/main/scala/io/github/karlhigley/lexrank/CosineLSH.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/CosineLSH.scala
@@ -1,0 +1,46 @@
+package io.github.karlhigley.lexrank
+
+import scala.collection.immutable.BitSet
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
+import scala.util.hashing.MurmurHash3
+
+import org.apache.spark.mllib.linalg.SparseVector
+import org.apache.spark.Logging
+
+class CosineLSH(poolSize: Int = 10000) extends Serializable with Logging {
+  val pool = CosineLSH.generatePool(poolSize)
+  
+  def computeSignature(vector: SparseVector, length: Int): BitSet = {
+    val buf = ArrayBuffer.empty[Int]
+    
+    val elements = vector.indices.zip(vector.values)
+    for (bit <- 1 to length) {
+      val components = elements.map(e => {
+          val hash      = MurmurHash3.productHash((bit, e._1))
+          val poolIndex = ((hash % poolSize) + poolSize) % poolSize
+          val result    = e._2 * pool(poolIndex)
+          result
+      })
+
+      val dotProduct = components.reduce(_ + _)
+      if (dotProduct > 0) {
+        buf += bit
+      }
+    }
+
+    BitSet(buf.toArray:_*)
+  }
+}
+
+object CosineLSH {
+  def signatureSet(length: Int): Set[BitSet] = {
+    BitSet(1 to length:_*).subsets.toSet
+  }
+
+  private def generatePool(size: Int): Array[Double] = {
+    val rand = new Random()
+    val buf  = ArrayBuffer.fill[Double](size)(rand.nextGaussian)
+    buf.toArray
+  }
+}

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -33,7 +33,12 @@ object Driver extends Logging {
       }
     )
 
-    val (sentences, features) = featurizer.featurize(documents)
+    val partitionedDocs = config.partitions match {
+      case Some(p) => documents.repartition(p)
+      case None    => documents
+    }
+
+    val (sentences, features) = featurizer.featurize(partitionedDocs)
 
     val model    = new LexRank(features)
     val ranks    = model.score(config.threshold, config.cutoff, config.convergence)

--- a/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
@@ -34,7 +34,11 @@ class Featurizer(stopwords: Set[String]) extends Serializable {
   private def tokenize(sentences: RDD[Sentence], stopwords: Set[String]) : RDD[SentenceTokens] = {
     val tokenizer = SimpleEnglishTokenizer()
     sentences.map(s => {
-      val tokens = tokenizer(s.text.toLowerCase).toSeq.filter(!stopwords.contains(_)).map(stem)
+      val tokens = tokenizer(s.text.toLowerCase).toSeq
+                                          .filter(_.length > 3)
+                                          .filter(!stopwords.contains(_))
+                                          .map(stem)
+
       SentenceTokens(s.id, s.docId, tokens)
     })
   }

--- a/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
@@ -18,7 +18,7 @@ class Featurizer(stopwords: Set[String]) extends Serializable {
   def featurize(documents: RDD[Document]) = {  
     val sentences = extractSentences(documents)
     val tokenized = tokenize(sentences, stopwords)
-    val features  = vectorize(tokenized)
+    val features  = vectorize(tokenized).filter(f => f.features.indices.size > 0)
     (sentences, features)
   }
 


### PR DESCRIPTION
In order to reduce the number of pairwise sentence comparisons, this PR applies locality-sensitive hashing to place similar sentences together in buckets, before computing similarities between the sentences in each bucket.  This improves both memory usage and performance.

(The commit messages contain further details on the algorithm, etc.)
