### PR TITLE
Combine input entries with the same identifier into a single document

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -36,10 +36,10 @@ object Driver extends Logging {
 
     val documents = sc.textFile(config.inputPath).flatMap( 
       _.split('\t').toList match {
-        case List(docId, text) => Some(Document(docId, text))
+        case List(docId, text) => Some((docId, text))
         case _                 => None
       }
-    )
+    ).reduceByKey(_ + " . " + _).map(Document.tupled)
 
     val partitionedDocs = config.partitions match {
       case Some(p) => documents.repartition(p)

--- a/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
@@ -25,6 +25,7 @@ class Featurizer(stopwords: Set[String]) extends Serializable {
   private def extractSentences(documents: RDD[Document]) : RDD[Sentence] = {
     documents
       .flatMap(d => segment(d.text).map(t => (d.id, t)) )
+      .distinct()
       .zipWithIndex()
       .map({
         case ((docId, sentenceText), sentenceId) => Sentence(sentenceId, docId, sentenceText)


### PR DESCRIPTION
Since entries with the same identifier may contain overlapping or the same
content, extract the distinct sentences from each document (i.e. filter out
duplicates within each document).
