### PR TITLE
Properly parse input lines with text containing tabs

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -36,7 +36,7 @@ object Driver extends Logging {
 
     val documents = sc.textFile(config.inputPath).flatMap( 
       _.split('\t').toList match {
-        case List(docId, text) => Some((docId, text))
+        case List(docId, text @ _*) => Some((docId, text.mkString(" ")))
         case _                 => None
       }
     ).reduceByKey(_ + " . " + _).map(Document.tupled)


### PR DESCRIPTION
Lines with text containing tabs were being split into lists with length > 2, and
were therefore ignored by the pattern match.  This fixes the pattern match so
that input lines are no longer ignored, and replaces the tabs with spaces.
