### PR TITLE
Revert "Combine input entries with the same identifier into a single …

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -39,7 +39,7 @@ object Driver extends Logging {
         case List(docId, text @ _*) => Some((docId, text.mkString(" ")))
         case _                 => None
       }
-    ).reduceByKey(_ + " . " + _).map(Document.tupled)
+    ).map(Document.tupled)
 
     val partitionedDocs = config.partitions match {
       case Some(p) => documents.repartition(p)

--- a/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
@@ -25,7 +25,6 @@ class Featurizer(stopwords: Set[String]) extends Serializable {
   private def extractSentences(documents: RDD[Document]) : RDD[Sentence] = {
     documents
       .flatMap(d => segment(d.text).map(t => (d.id, t)) )
-      .distinct()
       .zipWithIndex()
       .map({
         case ((docId, sentenceText), sentenceId) => Sentence(sentenceId, docId, sentenceText)


### PR DESCRIPTION
…document"

This reverts commit 015326ce81f53172d05bed1545cba2374ada2705.  It caused problems when converting from a CoordinateMatrix to a RowMatrix.  Specifically, it resulted in attempting to create a sparse vector with size 0, which is not allowed.  Not yet sure how the CoordinateMatrix ends up thinking it has zero columns, but reverting this in the mean time.
