### PR TITLE
Add basic tests for CosineLSH model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-mllib" % "1.3.1" % "provided",
   "org.scalanlp" %% "breeze" % "0.11.2",
   "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp"),
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
 )
 
 resolvers ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "1.3.1" % "provided",
   "org.apache.spark" %% "spark-mllib" % "1.3.1" % "provided",
   "org.scalanlp" %% "breeze" % "0.11.2",
-  "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp")
+  "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp"),
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 
 resolvers ++= Seq(
@@ -16,3 +17,5 @@ resolvers ++= Seq(
   "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
   "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
 )
+
+parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ version := "0.0.1"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.3.0" % "provided",
-  "org.apache.spark" %% "spark-mllib" % "1.3.0" % "provided",
+  "org.apache.spark" %% "spark-core" % "1.3.1" % "provided",
+  "org.apache.spark" %% "spark-mllib" % "1.3.1" % "provided",
   "org.scalanlp" %% "breeze" % "0.11.2",
   "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp")
 )

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+# Set everything to be logged to the file target/unit-tests.log
+log4j.rootCategory=INFO, file
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.append=true
+log4j.appender.file.file=target/unit-tests.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
+
+# Ignore messages below warning level from Jetty, because it's a bit verbose
+log4j.logger.org.spark-project.jetty=WARN

--- a/src/test/scala/io/github/karlhigley/lexrank/CosineLSHSuite.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/CosineLSHSuite.scala
@@ -1,0 +1,21 @@
+package io.github.karlhigley.lexrank
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.mllib.linalg.SparseVector
+
+class CosineLSHSuite extends FunSuite with TestSparkContext {
+  val lshModel = new CosineLSH
+
+  test("signatures are deterministic") {
+    val nonzero = new SparseVector(3, Array(1,2,3), Array(1,1,1))
+    val signatureA = lshModel.computeSignature(nonzero, 2)
+    val signatureB = lshModel.computeSignature(nonzero, 2)
+    assert(signatureA === signatureB)
+  }
+
+  test("zero vectors get signatures") {
+    val zero = new SparseVector(3, Array(1,2,3), Array(0,0,0))
+    val signature0 = lshModel.computeSignature(zero, 2)
+  }
+}

--- a/src/test/scala/io/github/karlhigley/lexrank/TestSparkContext.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/TestSparkContext.scala
@@ -1,0 +1,25 @@
+package io.github.karlhigley.lexrank
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+trait TestSparkContext extends BeforeAndAfterAll { self: Suite =>
+  @transient var sc: SparkContext = _
+
+  override def beforeAll() {
+    super.beforeAll()
+    val conf = new SparkConf()
+      .setMaster("local[2]")
+      .setAppName("LexRankUnitTest")
+    sc = new SparkContext(conf)
+  }
+
+  override def afterAll() {
+    if (sc != null) {
+      sc.stop()
+    }
+    sc = null    
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
This PR sets up testing infrastructure and adds two (very) simple tests for Cosine LSH computation.  That lays the groundwork for more testing and refactoring.
