### PR TITLE
Disentangle/test similarity computation and Lexrank model

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -45,7 +45,10 @@ object Driver extends Logging {
     val featurizer = new Featurizer
     val features = featurizer(tokenized)
 
-    val model    = new LexRank(features)
+    val comparer = new SimilarityComparison(config.threshold)
+    val comparisons = comparer(features)
+
+    val model    = new LexRank(features, comparisons)
     val ranks    = model.score(config.threshold, config.cutoff, config.convergence)
     val excerpts = selectExcerpts(sentences, ranks, config.length)
 

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -48,8 +48,8 @@ object Driver extends Logging {
     val comparer = new SimilarityComparison(config.threshold)
     val comparisons = comparer(features)
 
-    val model    = new LexRank(features, comparisons)
-    val ranks    = model.score(config.threshold, config.cutoff, config.convergence)
+    val model    = LexRank.build(features, comparisons)
+    val ranks    = model.score(config.cutoff, config.convergence)
     val excerpts = selectExcerpts(sentences, ranks, config.length)
 
     excerpts

--- a/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
@@ -35,7 +35,7 @@ object LexRank {
 
     val edges = comparisons
                   .flatMap(c => SentenceComparison.unapply(c))
-                  .map(e => Edge(e._1, e._2, e._3))    
+                  .flatMap(e => List(Edge(e._1, e._2, e._3), Edge(e._2, e._1, e._3)))    
 
     new LexRank(Graph(vertices, edges))
   }

--- a/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
@@ -1,22 +1,18 @@
 package io.github.karlhigley.lexrank
 
-import scala.math.{log, max}
+import scala.math.max
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.graphx._
 
-import org.apache.spark.mllib.linalg.{Vector, SparseVector}
-import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry, RowMatrix}
-
 case class SentenceComparison(id1: Long, id2: Long, similarity: Double)
 
-class LexRank(features: RDD[SentenceFeatures]) extends Serializable {
+class LexRank(features: RDD[SentenceFeatures], comparisons: RDD[SentenceComparison]) extends Serializable {
   def score(threshold: Double = 0.1, cutoff: Double = 0.8, convergence: Double = 0.001) = {    
-    buildGraph(features, threshold, cutoff).pageRank(convergence).vertices    
+    buildGraph(features, comparisons, threshold, cutoff).pageRank(convergence).vertices    
   }
 
-  private def buildGraph(features: RDD[SentenceFeatures], threshold: Double, cutoff: Double): Graph[String, Double] = {
-    val comparisons         = compareSentences(features, threshold)
+  private def buildGraph(features: RDD[SentenceFeatures], comparisons: RDD[SentenceComparison], threshold: Double, cutoff: Double): Graph[String, Double] = {
     val filteredGraph       = removeBoilerplate(comparisons, cutoff)
 
     val docIds              = features.map(f => (f.id, f.docId))
@@ -51,58 +47,5 @@ class LexRank(features: RDD[SentenceFeatures]) extends Serializable {
       epred = (triplet)   => triplet.srcAttr == triplet.dstAttr,
       vpred = (id, attr)  => attr != ""
     )
-  }
-
-  private def compareSentences(sentences: RDD[SentenceFeatures], threshold: Double): RDD[SentenceComparison] = {
-    val maxColumn = sentences.map(_.id).reduce(math.max(_, _)) + 1
-
-    val matrices = bucketSentences(sentences).map(buildRowMatrix(_, 1 << 20, maxColumn))
-    matrices.foreach(_.rows.persist())
-
-    val similarities = matrices
-                          .map(computeSimilarities(_, threshold))
-                          .reduce(_ union _)
-                          .coalesce(sentences.partitions.size)
-
-    similarities.persist()
-    similarities.count()
-
-    matrices.foreach(_.rows.unpersist())
-
-    similarities.flatMap(MatrixEntry.unapply(_)).map(SentenceComparison.tupled)
-  }
-
-  private def bucketSentences(sentences: RDD[SentenceFeatures]) = {
-    val signatureGen  = new CosineLSH
-    val signatureBits = (log(sentences.partitions.size)/log(2)).toInt
-    
-    val signatures    = features.map(f => {
-      (signatureGen.computeSignature(f.features, signatureBits), f)
-    })
-    
-    CosineLSH
-      .signatureSet(signatureBits)
-      .map(k => {
-        signatures.filter(s => s._1 == k).map(s => s._2)
-      })
-  }
-
-  private def buildRowMatrix(columns: RDD[SentenceFeatures], rowCount: Long, colCount: Long) : RowMatrix = {
-    val matrixEntries = columns.flatMap {
-      case SentenceFeatures(colNum, _, vector) =>
-        sparseElements(vector).map {
-          case (rowNum, value) => MatrixEntry(rowNum, colNum, value)
-        }
-    }
-
-    new CoordinateMatrix(matrixEntries, rowCount, colCount).toRowMatrix()
-  }
-
-  private def sparseElements(vector: SparseVector): Seq[(Int, Double)] = {
-    vector.indices.zip(vector.values)
-  }
-
-  private def computeSimilarities(matrix: RowMatrix, threshold: Double): RDD[MatrixEntry] = {
-    matrix.columnSimilarities(threshold).entries.filter(_.value > threshold)
   }
 }

--- a/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
@@ -7,45 +7,36 @@ import org.apache.spark.graphx._
 
 case class SentenceComparison(id1: Long, id2: Long, similarity: Double)
 
-class LexRank(features: RDD[SentenceFeatures], comparisons: RDD[SentenceComparison]) extends Serializable {
-  def score(threshold: Double = 0.1, cutoff: Double = 0.8, convergence: Double = 0.001) = {    
-    buildGraph(features, comparisons, threshold, cutoff).pageRank(convergence).vertices    
+class LexRank(graph: Graph[String, Double]) extends Serializable {
+  def score(cutoff: Double = 0.8, convergence: Double = 0.001) : VertexRDD[Double] = {
+    filterBoilerplate(graph, cutoff).pageRank(convergence).vertices
   }
 
-  private def buildGraph(features: RDD[SentenceFeatures], comparisons: RDD[SentenceComparison], threshold: Double, cutoff: Double): Graph[String, Double] = {
-    val filteredGraph       = removeBoilerplate(comparisons, cutoff)
-
-    val docIds              = features.map(f => (f.id, f.docId))
-    val documentComponents  = removeCrossDocEdges(filteredGraph, docIds)
-
-    documentComponents
-  }
-
-  private def removeBoilerplate(comparisons: RDD[SentenceComparison], boilerplateCutoff: Double): Graph[Double, Double] = {
-    val edges = comparisons
-                  .flatMap(c => SentenceComparison.unapply(c))
-                  .map(e => Edge(e._1, e._2, e._3))
-
-    val maxSimilarityVertices = Graph.fromEdges(edges, 0).aggregateMessages[Double](
+  private def filterBoilerplate(graph: Graph[String, Double], cutoff: Double): Graph[String, Double] = {
+    val maxSimilarityVertices = Graph.fromEdges(graph.edges, 0).aggregateMessages[Double](
       sendMsg       = triplet => triplet.sendToDst(triplet.attr),
       mergeMsg      = (a, b) => max(a,b),
       tripletFields = TripletFields.EdgeOnly
     )
 
-    val maxSimilarityGraph: Graph[Double, Double] = Graph(maxSimilarityVertices, edges, 1.0)
-    maxSimilarityGraph.subgraph(vpred = (id, attr) => attr < boilerplateCutoff)  
-  }
+    val maxSimilarityGraph: Graph[Double, Double] = Graph(maxSimilarityVertices, graph.edges, 1.0)
+    val filteredGraph = maxSimilarityGraph.subgraph(vpred = (id, attr) => attr < cutoff)
 
-  private def removeCrossDocEdges(graph: Graph[Double, Double], docIds: RDD[(Long, String)]): Graph[String, Double] = {
-    val docGraph: Graph[String, Double] = graph.outerJoinVertices(docIds)(
-      (id, similarity, docIdOpt) => docIdOpt match {
-        case Some(docId)  => docId
-        case None         => ""
-      }
-    )
-    docGraph.subgraph(
+    graph.mask(filteredGraph).subgraph(
       epred = (triplet)   => triplet.srcAttr == triplet.dstAttr,
       vpred = (id, attr)  => attr != ""
     )
+  }
+}
+
+object LexRank {
+  def build(features: RDD[SentenceFeatures], comparisons: RDD[SentenceComparison]): LexRank = {
+    val vertices = features.map(f => (f.id, f.docId))
+
+    val edges = comparisons
+                  .flatMap(c => SentenceComparison.unapply(c))
+                  .map(e => Edge(e._1, e._2, e._3))    
+
+    new LexRank(Graph(vertices, edges))
   }
 }

--- a/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
@@ -1,0 +1,64 @@
+package io.github.karlhigley.lexrank
+
+import scala.math.{log, max}
+
+import org.apache.spark.rdd.RDD
+
+import org.apache.spark.mllib.linalg.{Vector, SparseVector}
+import org.apache.spark.mllib.linalg.distributed.{CoordinateMatrix, MatrixEntry, RowMatrix}
+
+class SimilarityComparison(threshold: Double) extends Serializable {
+  val signatureGen = new CosineLSH
+
+  def apply(sentences: RDD[SentenceFeatures]): RDD[SentenceComparison] = {
+    val maxColumn = sentences.map(_.id).reduce(math.max(_, _)) + 1
+
+    val matrices = bucketSentences(sentences).map(buildRowMatrix(_, 1 << 20, maxColumn))
+    matrices.foreach(_.rows.persist())
+
+    val similarities = matrices
+                          .map(computeSimilarities(_, threshold))
+                          .reduce(_ union _)
+                          .coalesce(sentences.partitions.size)
+
+    similarities.persist()
+    similarities.count()
+
+    matrices.foreach(_.rows.unpersist())
+
+    similarities.flatMap(MatrixEntry.unapply(_)).map(SentenceComparison.tupled)
+  }
+
+  private def computeSimilarities(matrix: RowMatrix, threshold: Double): RDD[MatrixEntry] = {
+    matrix.columnSimilarities(threshold).entries.filter(_.value > threshold)
+  }
+
+  private def bucketSentences(sentences: RDD[SentenceFeatures]) = {
+    val signatureBits = (log(sentences.partitions.size)/log(2)).toInt
+    
+    val signatures    = sentences.map(s => {
+      (signatureGen.computeSignature(s.features, signatureBits), s)
+    })
+    
+    CosineLSH
+      .signatureSet(signatureBits)
+      .map(k => {
+        signatures.filter(s => s._1 == k).map(s => s._2)
+      })
+  }
+
+  private def buildRowMatrix(columns: RDD[SentenceFeatures], rowCount: Long, colCount: Long) : RowMatrix = {
+    val matrixEntries = columns.flatMap {
+      case SentenceFeatures(colNum, _, vector) =>
+        sparseElements(vector).map {
+          case (rowNum, value) => MatrixEntry(rowNum, colNum, value)
+        }
+    }
+
+    new CoordinateMatrix(matrixEntries, rowCount, colCount).toRowMatrix()
+  }
+
+  private def sparseElements(vector: SparseVector): Seq[(Int, Double)] = {
+    vector.indices.zip(vector.values)
+  }
+}

--- a/src/test/scala/io/github/karlhigley/lexrank/LexRankSuite.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/LexRankSuite.scala
@@ -1,0 +1,39 @@
+package io.github.karlhigley.lexrank
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.mllib.linalg.SparseVector
+
+case class SentenceFeatures(id: Long, docId: String, features: SparseVector)
+
+class LexRankSuite extends FunSuite with TestSparkContext {
+  val feature1 = SentenceFeatures(1L, "doc1", new SparseVector(100, Array(), Array()))
+  val feature2 = SentenceFeatures(2L, "doc2", new SparseVector(100, Array(), Array()))
+  val feature3 = SentenceFeatures(3L, "doc2", new SparseVector(100, Array(), Array()))
+
+  test("vertices above similarity cutoff are removed") {
+    val features = sc.parallelize(List(feature1, feature2))
+
+    val comparison1 = SentenceComparison(1L, 2L, 0.9)
+    val comparisons = sc.parallelize(List(comparison1))
+
+    val lexrank = LexRank.build(features, comparisons)
+
+    val scores = lexrank.score(cutoff = 0.8)
+
+    assert(scores.count() === 0)
+  }
+
+  test("vertices below similarity cutoff are retained") {
+    val features = sc.parallelize(List(feature2, feature3))
+
+    val comparison1 = SentenceComparison(2L, 3L, 0.5)
+    val comparisons = sc.parallelize(List(comparison1))
+
+    val lexrank = LexRank.build(features, comparisons)
+
+    val scores = lexrank.score(cutoff = 0.8)
+
+    assert(scores.count() === 2)
+  }
+}

--- a/src/test/scala/io/github/karlhigley/lexrank/SimilarityComparisonSuite.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/SimilarityComparisonSuite.scala
@@ -1,0 +1,29 @@
+package io.github.karlhigley.lexrank
+
+import org.scalatest.FunSuite
+
+import org.apache.spark.mllib.linalg.SparseVector
+
+class SimilarityComparisonSuite extends FunSuite with TestSparkContext {
+  val feature1 = SentenceFeatures(1L, "doc1", new SparseVector(100, Array(1,2,3), Array(1,1,1)))
+  val feature2 = SentenceFeatures(2L, "doc1", new SparseVector(100, Array(4,5,6), Array(2,2,2)))
+  val feature3 = SentenceFeatures(3L, "doc1", new SparseVector(100, Array(4,5,6), Array(2,2,2)))
+
+  test("similarities below the threshold are omitted") {
+    val features = sc.parallelize(List(feature1, feature2))
+
+    val comparer = new SimilarityComparison(0.1)
+    val comparisons = comparer(features)
+
+    assert(comparisons.count() === 0)
+  }
+
+  test("similar pairs get high similarity score") {
+    val features = sc.parallelize(List(feature2, feature3))
+
+    val comparer = new SimilarityComparison(0.1)
+    val comparisons = comparer(features)
+
+    assert(comparisons.first().similarity > 0.5)
+  }
+}


### PR DESCRIPTION
This separates the similarity computation from the LexRank model, which makes both easier to test, and adds some simple sanity check tests.  Along the way, discovered two issues:
- GraphX edges are directed, so need to create two edges between each pair of vertices
- It's possible (but unlikely) that an LSH bucket will be empty, which could cause a failure
