### PR TITLE
Cache (LSH signature, feature vector) pairs

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
@@ -38,7 +38,8 @@ class SimilarityComparison(threshold: Double) extends Serializable {
     
     val signatures    = sentences.map(s => {
       (signatureGen.computeSignature(s.features, signatureBits), s)
-    })
+    }).cache()
+    signatures.count()
     
     CosineLSH
       .signatureSet(signatureBits)


### PR DESCRIPTION
This provides a significant speed-up when computing matrix column statistics.
