### PR TITLE
Consolidate input document content by doc ID

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/DocumentSegmenter.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/DocumentSegmenter.scala
@@ -23,6 +23,7 @@ class DocumentSegmenter(stopwords: Set[String]) extends Serializable {
   private def extractSentences(documents: RDD[Document]) : RDD[Sentence] = {
     documents
       .flatMap(d => segment(d.text).map(t => (d.id, t)) )
+      .distinct()
       .zipWithIndex()
       .map({
         case ((docId, sentenceText), sentenceId) => Sentence(sentenceId, docId, sentenceText)

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -38,7 +38,7 @@ object Driver extends Logging {
         case List(docId, text @ _*) => Some((docId, text.mkString(" ")))
         case _                 => None
       }
-    ).map(Document.tupled)
+    ).reduceByKey(_ + _).map(Document.tupled)
 
     val segmenter = new DocumentSegmenter(stopwords)
     val (sentences, tokenized) = segmenter(documents)

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -35,10 +35,10 @@ object Driver extends Logging {
     
     val documents = sc.textFile(config.inputPath, minPartitions = config.partitions).flatMap( 
       _.split('\t').toList match {
-        case List(docId, text @ _*) => Some((docId, text.mkString(" ")))
+        case List(docId, text @ _*) => Some((docId.trim, text.mkString(" ")))
         case _                 => None
       }
-    ).reduceByKey(_ + _).map(Document.tupled)
+    ).reduceByKey(_ + _).map(Document.tupled).filter(d => d.id.length > 0)
 
     val segmenter = new DocumentSegmenter(stopwords)
     val (sentences, tokenized) = segmenter(documents)

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -43,8 +43,10 @@ object Driver extends Logging {
     val segmenter = new DocumentSegmenter(stopwords)
     val (sentences, tokenized) = segmenter(documents)
 
+    val tokenizedFilteredByLength = tokenized.filter(t => t.tokens.size > 2)
+
     val featurizer = new Featurizer
-    val features = featurizer(tokenized)
+    val features = featurizer(tokenizedFilteredByLength).cache()
 
     val comparer = new SimilarityComparison(config.threshold, config.buckets)
     val comparisons = comparer(features)


### PR DESCRIPTION
This combines input from multiple document entries with the same doc ID into a single document. In order to make that work as intended, it also trims whitespace from the document IDs, suppresses sentences with blank doc IDS or too few tokens (less than 3), and removes duplicate sentences within a single document.
