### PR TITLE
Represent similarities as Floats instead of Doubles in LexRank

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Configuration.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Configuration.scala
@@ -8,9 +8,9 @@ class Configuration(args: Array[String]) {
   var partitions    = 2
   var buckets       = 64
   var length        = 5
-  var cutoff        = 0.8
-  var threshold     = 0.1
-  var convergence   = 0.001
+  var cutoff        = 0.8f
+  var threshold     = 0.1f
+  var convergence   = 0.001f
 
   parse(args.toList)
 
@@ -40,15 +40,15 @@ class Configuration(args: Array[String]) {
       parse(tail)
 
     case ("--boilerplate" | "-b") :: value :: tail =>
-      cutoff = value.toDouble
+      cutoff = value.toFloat
       parse(tail)
 
     case ("--threshold" | "-t") :: value :: tail =>
-      threshold = value.toDouble
+      threshold = value.toFloat
       parse(tail)
 
     case ("--convergence" | "-c") :: value :: tail =>
-      convergence = value.toDouble
+      convergence = value.toFloat
       parse(tail)
 
     case ("--help" | "-h") :: tail =>

--- a/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/LexRank.scala
@@ -5,21 +5,21 @@ import scala.math.max
 import org.apache.spark.rdd.RDD
 import org.apache.spark.graphx._
 
-case class SentenceComparison(id1: Long, id2: Long, similarity: Double)
+case class SentenceComparison(id1: Long, id2: Long, similarity: Float)
 
-class LexRank(graph: Graph[String, Double]) extends Serializable {
-  def score(cutoff: Double = 0.8, convergence: Double = 0.001) : VertexRDD[Double] = {
+class LexRank(graph: Graph[String, Float]) extends Serializable {
+  def score(cutoff: Float = 0.8f, convergence: Float = 0.001f) : VertexRDD[Double] = {
     filterBoilerplate(graph, cutoff).pageRank(convergence).vertices
   }
 
-  private def filterBoilerplate(graph: Graph[String, Double], cutoff: Double): Graph[String, Double] = {
-    val maxSimilarityVertices = Graph.fromEdges(graph.edges, 0).aggregateMessages[Double](
+  private def filterBoilerplate(graph: Graph[String, Float], cutoff: Float): Graph[String, Float] = {
+    val maxSimilarityVertices = Graph.fromEdges(graph.edges, 0).aggregateMessages[Float](
       sendMsg       = triplet => triplet.sendToDst(triplet.attr),
       mergeMsg      = (a, b) => max(a,b),
       tripletFields = TripletFields.EdgeOnly
     )
 
-    val maxSimilarityGraph: Graph[Double, Double] = Graph(maxSimilarityVertices, graph.edges, 1.0)
+    val maxSimilarityGraph: Graph[Float, Float] = Graph(maxSimilarityVertices, graph.edges, 1.0f)
     val filteredGraph = maxSimilarityGraph.subgraph(vpred = (id, attr) => attr < cutoff)
 
     graph.mask(filteredGraph).subgraph(

--- a/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/SimilarityComparison.scala
@@ -26,7 +26,7 @@ class SimilarityComparison(threshold: Double, buckets: Int) extends Serializable
 
     matrices.foreach(_.rows.unpersist())
 
-    similarities.flatMap(MatrixEntry.unapply(_)).map(SentenceComparison.tupled)
+    similarities.flatMap(MatrixEntry.unapply(_)).map(s => SentenceComparison(s._1, s._2, s._3.toFloat))
   }
 
   private def computeSimilarities(matrix: RowMatrix, threshold: Double): RDD[MatrixEntry] = {

--- a/src/test/scala/io/github/karlhigley/lexrank/LexRankSuite.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/LexRankSuite.scala
@@ -14,12 +14,12 @@ class LexRankSuite extends FunSuite with TestSparkContext {
   test("vertices above similarity cutoff are removed") {
     val features = sc.parallelize(List(feature1, feature2))
 
-    val comparison1 = SentenceComparison(1L, 2L, 0.9)
+    val comparison1 = SentenceComparison(1L, 2L, 0.9f)
     val comparisons = sc.parallelize(List(comparison1))
 
     val lexrank = LexRank.build(features, comparisons)
 
-    val scores = lexrank.score(cutoff = 0.8)
+    val scores = lexrank.score(cutoff = 0.8f)
 
     assert(scores.count() === 0)
   }
@@ -27,12 +27,12 @@ class LexRankSuite extends FunSuite with TestSparkContext {
   test("vertices below similarity cutoff are retained") {
     val features = sc.parallelize(List(feature2, feature3))
 
-    val comparison1 = SentenceComparison(2L, 3L, 0.5)
+    val comparison1 = SentenceComparison(2L, 3L, 0.5f)
     val comparisons = sc.parallelize(List(comparison1))
 
     val lexrank = LexRank.build(features, comparisons)
 
-    val scores = lexrank.score(cutoff = 0.8)
+    val scores = lexrank.score(cutoff = 0.8f)
 
     assert(scores.count() === 2)
   }


### PR DESCRIPTION
The precision of a Double isn't necessary for the simple comparisons that are
used, and this saves a few bytes per graph edge (which adds up quickly).
