### PR TITLE
Stop combining documents with the same identifier during pre-processing

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/DocumentSegmenter.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/DocumentSegmenter.scala
@@ -23,7 +23,6 @@ class DocumentSegmenter(stopwords: Set[String]) extends Serializable {
   private def extractSentences(documents: RDD[Document]) : RDD[Sentence] = {
     documents
       .flatMap(d => segment(d.text).map(t => (d.id, t)) )
-      .distinct()
       .zipWithIndex()
       .map({
         case ((docId, sentenceText), sentenceId) => Sentence(sentenceId, docId, sentenceText)

--- a/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Driver.scala
@@ -38,7 +38,7 @@ object Driver extends Logging {
         case List(docId, text @ _*) => Some((docId.trim, text.mkString(" ")))
         case _                 => None
       }
-    ).reduceByKey(_ + _).map(Document.tupled).filter(d => d.id.length > 0)
+    ).map(Document.tupled).filter(d => d.id.length > 0)
 
     val segmenter = new DocumentSegmenter(stopwords)
     val (sentences, tokenized) = segmenter(documents)


### PR DESCRIPTION
Now that the boilerplate filtering should detect exact duplicates across all
documents and near duplicates within each document, this bit of pre-processing
no longer makes sense. Concatenating documents in this way mostly leads to
problems in the sentence segmentation, and doesn't have a concrete benefit
(given the boilerplate filtering).
