### PR TITLE
Remove extraneous launch script

### DIFF
--- a/lexrank
+++ b/lexrank
@@ -1,1 +1,0 @@
-time spark-submit --driver-memory 2g --executor-memory 2g --class io.github.karlhigley.lexrank.Driver target/scala-2.10/lexrank-summarizer-assembly-0.0.1.jar


### PR DESCRIPTION
This was handy on my dev machine at one point, but on an EC2 cluster, it's better
to use the default driver and executor memory settings (which are already tuned
to the instance size.)
