### PR TITLE
Replace explicit removal of zeros with conversion to SparseVector

### DIFF
--- a/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
+++ b/src/main/scala/io/github/karlhigley/lexrank/Featurizer.scala
@@ -21,10 +21,7 @@ class Featurizer extends Serializable {
     termFrequencies
       .map({
         case (id, docId, tf) =>
-          val tfidfVector = idf.transform(tf).asInstanceOf[SparseVector]
-          val (indices, values) = tfidfVector.indices.zip(tfidfVector.values).filter(_._2 > 0.0).unzip
-          val featureVector = new SparseVector(tfidfVector.size, indices.toArray, values.toArray)
-          SentenceFeatures(id, docId, featureVector)
+          SentenceFeatures(id, docId, idf.transform(tf).toSparse)
       })
       .filter(_.features.indices.size > 0)
   }

--- a/src/test/scala/io/github/karlhigley/lexrank/FeaturizerSuite.scala
+++ b/src/test/scala/io/github/karlhigley/lexrank/FeaturizerSuite.scala
@@ -9,6 +9,14 @@ class FeaturizerSuite extends FunSuite with TestSparkContext {
 
   val featurizer = new Featurizer
 
+  test("feature vectors include only non-zero entries") {
+    val sentences = sc.parallelize(List(sentence1, sentence2, sentence3))
+    val featurized = featurizer(sentences).collect()
+    featurized.foreach { f =>
+        assert(!f.features.values.contains(0.0))
+    }
+  }
+
   test("single occurrence tokens are ignored") {
     val sentences = sc.parallelize(List(sentence1, sentence2, sentence3))
     val featurized = featurizer(sentences).collect()


### PR DESCRIPTION
Annoyingly, the IDF transform outputs SparseVectors with explicit zeros for any
features below the `minDocFreq` threshold, which partially compromises the
sparsity. When this code was originally written, the `toSparse` conversion
hadn't yet been included in Spark's vectors API. Since it removes explicit zeros
during the conversion, this code can be simplified quite a bit.
